### PR TITLE
symfony-docs-ja#176の対応につきまして

### DIFF
--- a/tempja/source/conf.py
+++ b/tempja/source/conf.py
@@ -29,8 +29,8 @@ sys.path.append(os.path.abspath('_exts'))
 #extensions = ['configurationblock']
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest',
               'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.ifconfig',
-              'sphinx.ext.viewcode', 'sphinx.ext.extlinks', 'configurationblock',
-              'sphinxcontrib.phpdomain',]
+              'sphinx.ext.viewcode', 'sphinx.ext.extlinks', 
+              'sensio.sphinx.refinclude', 'sensio.sphinx.configurationblock', 'sensio.sphinx.phpcode',]
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
@@ -93,7 +93,10 @@ from sphinx.highlighting import lexers
 from pygments.lexers.web import PhpLexer
 lexers['php'] = PhpLexer(startinline=True)
 lexers['php-annotations'] = PhpLexer(startinline=True)
+lexers['php-standalone'] = PhpLexer(startinline=True)
+lexers['php-symfony'] = PhpLexer(startinline=True)
 
+api_url = 'http://api.symfony.com/master/%s'
 #from pygments.lexers.web import PhpLexer
 #PhpLexer.startinline = True
 


### PR DESCRIPTION
お世話になっております。yositani2002です。

symfony-japan/symfony-docs-ja　#176 の対応になります。

virtualenv経由のpipでsphinx-phpを入れまして、実行いたしました。

``` bash
$ cd ~
$ virtualenv symfonyja
$ source symfonyja/bin/activate
(symfonyja)$ pip install git+https://github.com/fabpot/sphinx-php.git
(symfonyja)$ pip list
docutils (0.11)
Jinja2 (2.7.3)
MarkupSafe (0.23)
pip (1.5.4)
Pygments (1.6)
setuptools (2.2)
Sphinx (1.2.2)
sphinx-php (1.0)
(symfonyja)$ sudo pip list
iniparse (0.3.1)
pip (1.5.6)
pycurl (7.19.0)
pygpgme (0.1)
setuptools (3.6)
urlgrabber (3.9.1)
virtualenv (1.11.6)
yum-metadata-parser (1.1.2)
(symfonyja)$ git clone https://github.com/symfony-japan/symfony-docs-ja-sphinx.git
(symfonyja)$ cd symfony-docs-ja-sphinx
(symfonyja)$ vi tempja/source/conf.py ///当該編集を入れました
(symfonyja)$ sh build.sh
```

api_urlを入れたことで、apiのサーバーへのリンクが出るようになったようです。

よろしくお願いいたします。
